### PR TITLE
Add hls-1.5.1

### DIFF
--- a/ghcup-0.0.6.yaml
+++ b/ghcup-0.0.6.yaml
@@ -2543,9 +2543,7 @@ ghcupDownloads:
               dlUri: https://downloads.haskell.org/ghcup/unofficial-bindists/haskell-language-server/1.4.0/haskell-language-server-linux-armv7-1.4.0.tar.gz
               dlHash: 4a921fbca06b02f3b1c0930cec5e65e9362b603e7715680ec7b150f18bd703d6
     1.5.0:
-      viTags:
-        - Recommended
-        - Latest
+      viTags: []
       viChangeLog: https://github.com/haskell/haskell-language-server/blob/master/ChangeLog.md#150
       viPostInstall: *hls-post-install
       viSourceDL:
@@ -2586,6 +2584,51 @@ ghcupDownloads:
             unknown_versioning:
               dlUri: https://downloads.haskell.org/ghcup/unofficial-bindists/haskell-language-server/1.5.0/haskell-language-server-linux-armv7-1.5.0.tar.xz
               dlHash: 7115c5861d8d30206ba2600d1a294539f3a15c09a1cb88ce48ac75dc5034e38a
+    1.5.1:
+      viTags:
+        - Recommended
+        - Latest
+      viChangeLog: https://github.com/haskell/haskell-language-server/blob/master/ChangeLog.md#151
+      viPostInstall: *hls-post-install
+      viSourceDL:
+        dlUri: https://github.com/haskell/haskell-language-server/releases/download/1.5.1/haskell-language-server-1.5.1-src.tar.gz
+        dlSubdir: haskell-language-server-1.5.1
+        dlHash: 8c6406f46181f31e2314ec008bd290bfcdfe2c6126851934b3b11d7d0266c554
+      viArch:
+        A_64:
+          Linux_UnknownLinux:
+            unknown_versioning: &hls-151-64
+              dlUri: https://github.com/haskell/haskell-language-server/releases/download/1.5.1/haskell-language-server-Linux-1.5.1.tar.gz
+              dlHash: 9fcd5f97de4efa92534b199965aa4aff7907fdc0eff4e2ae5af4c8b33cca2acc
+          Darwin:
+            unknown_versioning:
+              dlUri: https://github.com/haskell/haskell-language-server/releases/download/1.5.1/haskell-language-server-macOS-1.5.1.tar.gz
+              dlHash: 9efcff9ed2b8f07176899dfdb1b2ad6161f994e56102cf020cbe9602ad0a0e34
+          FreeBSD:
+            unknown_versioning:
+              dlUri: https://downloads.haskell.org/ghcup/unofficial-bindists/haskell-language-server/1.5.1/haskell-language-server-FreeBSD-1.5.1.tar.xz
+              dlHash: ?
+          Windows:
+            unknown_versioning:
+              dlUri: https://github.com/haskell/haskell-language-server/releases/download/1.5.1/haskell-language-server-Windows-1.5.1.tar.gz
+              dlHash: 353756304f8a912e329a6d18e588560d3ee8d34fe5ca14a0c7adee787d350bb0
+          Linux_Alpine:
+            unknown_versioning: *hls-151-64
+        A_ARM64:
+          Linux_UnknownLinux:
+            unknown_versioning:
+              dlUri: https://downloads.haskell.org/ghcup/unofficial-bindists/haskell-language-server/1.5.1/haskell-language-server-linux-aarch64-1.5.1.tar.xz
+              dlHash: ?
+          Darwin:
+            unknown_versioning:
+              dlUri: https://downloads.haskell.org/ghcup/unofficial-bindists/haskell-language-server/1.5.1/haskell-language-server-macOS-aarch64-1.5.1.tar.xz
+              dlHash: ?
+        A_ARM:
+          Linux_UnknownLinux:
+            unknown_versioning:
+              dlUri: https://downloads.haskell.org/ghcup/unofficial-bindists/haskell-language-server/1.5.1/haskell-language-server-linux-armv7-1.5.1.tar.xz
+              dlHash: ?
+
   Stack:
     2.5.1:
       viTags:
@@ -2596,7 +2639,7 @@ ghcupDownloads:
         GHC versions you can run the following commands:
           stack config set install-ghc false --global
           stack config set system-ghc  true  --global
-        
+
         On windows, you may find the following config options useful too:
           skip-msys, extra-path, extra-include-dirs, extra-lib-dirs
 

--- a/ghcup-0.0.6.yaml
+++ b/ghcup-0.0.6.yaml
@@ -2593,21 +2593,21 @@ ghcupDownloads:
       viSourceDL:
         dlUri: https://github.com/haskell/haskell-language-server/releases/download/1.5.1/haskell-language-server-1.5.1-src.tar.gz
         dlSubdir: haskell-language-server-1.5.1
-        dlHash: 8c6406f46181f31e2314ec008bd290bfcdfe2c6126851934b3b11d7d0266c554
+        dlHash: fa2b1d39d413283202ee1f75e4ad9fc44544535741370d6f1e63afd5878d9e40
       viArch:
         A_64:
           Linux_UnknownLinux:
             unknown_versioning: &hls-151-64
               dlUri: https://github.com/haskell/haskell-language-server/releases/download/1.5.1/haskell-language-server-Linux-1.5.1.tar.gz
-              dlHash: 9fcd5f97de4efa92534b199965aa4aff7907fdc0eff4e2ae5af4c8b33cca2acc
+              dlHash: 8c6406f46181f31e2314ec008bd290bfcdfe2c6126851934b3b11d7d0266c554
           Darwin:
             unknown_versioning:
               dlUri: https://github.com/haskell/haskell-language-server/releases/download/1.5.1/haskell-language-server-macOS-1.5.1.tar.gz
               dlHash: 9efcff9ed2b8f07176899dfdb1b2ad6161f994e56102cf020cbe9602ad0a0e34
           FreeBSD:
             unknown_versioning:
-              dlUri: https://downloads.haskell.org/ghcup/unofficial-bindists/haskell-language-server/1.5.1/haskell-language-server-FreeBSD-1.5.1.tar.xz
-              dlHash: ?
+              dlUri: https://github.com/haskell/haskell-language-server/releases/download/1.5.1/haskell-language-server-FreeBSD-1.5.1.tar.xz
+              dlHash: 79d0ca919800f361dca9d69ce822b6ac178f60c6594925e24e8931f9328e68c6
           Windows:
             unknown_versioning:
               dlUri: https://github.com/haskell/haskell-language-server/releases/download/1.5.1/haskell-language-server-Windows-1.5.1.tar.gz
@@ -2617,17 +2617,17 @@ ghcupDownloads:
         A_ARM64:
           Linux_UnknownLinux:
             unknown_versioning:
-              dlUri: https://downloads.haskell.org/ghcup/unofficial-bindists/haskell-language-server/1.5.1/haskell-language-server-linux-aarch64-1.5.1.tar.xz
-              dlHash: ?
+              dlUri: https://github.com/haskell/haskell-language-server/releases/download/1.5.1/haskell-language-server-Linux-aarch64-1.5.1.tar.xz
+              dlHash: 1f4252132f1eec5d84f5e5b7a296e90f2c8ab401f07f3a3de645110ba0190894
           Darwin:
             unknown_versioning:
-              dlUri: https://downloads.haskell.org/ghcup/unofficial-bindists/haskell-language-server/1.5.1/haskell-language-server-macOS-aarch64-1.5.1.tar.xz
-              dlHash: ?
+              dlUri: https://github.com/haskell/haskell-language-server/releases/download/1.5.1/haskell-language-server-macOS-aarch64-1.5.1.tar.xz
+              dlHash: af8f5038678f8e16466a885e9d56dc9ae750d1e19426c16716410d032515c7fc
         A_ARM:
           Linux_UnknownLinux:
             unknown_versioning:
-              dlUri: https://downloads.haskell.org/ghcup/unofficial-bindists/haskell-language-server/1.5.1/haskell-language-server-linux-armv7-1.5.1.tar.xz
-              dlHash: ?
+              dlUri: https://github.com/haskell/haskell-language-server/releases/download/1.5.1/haskell-language-server-Linux-armv7-1.5.1.tar.xz
+              dlHash: d28beb003581d5a2133099fd59c83a49af850e7b5cbca72fb3df088d218e0f2b
 
   Stack:
     2.5.1:


### PR DESCRIPTION
* The artifacts from https://gitlab.haskell.org/haskell/haskell-language-server/-/pipelines/44521 should be copied in https://downloads.haskell.org/ghcup/unofficial-bindists/haskell-language-server/1.5.1/
  * is there someway to do it automatically? 
* The artifact for freebsd is missing as itfailed in the linked pipeline
* It still needs sha256sum for those artifacts