### PR TITLE
Fix bindist for GHC 9.4.1 and 9.4.2 for old GLIBCs

### DIFF
--- a/ghcup-0.0.7.yaml
+++ b/ghcup-0.0.7.yaml
@@ -2499,7 +2499,7 @@ ghcupDownloads:
           Linux_RedHat:
             unknown_versioning: *ghc-941-64-centos
           Linux_UnknownLinux:
-            unknown_versioning: *ghc-941-64-fedora
+            unknown_versioning: *ghc-941-64-centos
           Darwin:
             unknown_versioning:
               dlUri: https://downloads.haskell.org/ghcup/unofficial-bindists/ghc/curated/9.4.1/ghc-9.4.1-x86_64-apple-darwin.tar.xz
@@ -2586,7 +2586,7 @@ ghcupDownloads:
           Linux_RedHat:
             unknown_versioning: *ghc-942-64-centos
           Linux_UnknownLinux:
-            unknown_versioning: *ghc-942-64-fedora
+            unknown_versioning: *ghc-942-64-centos
           Darwin:
             unknown_versioning:
               dlUri: https://downloads.haskell.org/~ghc/9.4.2/ghc-9.4.2-x86_64-apple-darwin.tar.xz


### PR DESCRIPTION
This will break cabal cache and HLS ABI.

@wz1000 

----

Centos 7 bindist compat info:

1. glibc 2.17
2. libtinfo.so.5
3. libgmp.so.10

```
[ghc@1de2333cecae ~]$ objdump -T /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/ghc | grep GLIBC
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 __libc_start_main
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 memset
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 getuid
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 getlogin
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.14  memcpy
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.2.5 memchr

[ghc@1de2333cecae ~]$ ldd /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/ghc
	linux-vdso.so.1 (0x00007fff42f06000)
	libm.so.6 => /lib64/libm.so.6 (0x00007fc0e668a000)
	libHShaskeline-0.8.2-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHShaskeline-0.8.2-ghc9.4.2.so (0x00007fc0e6a06000)
	libHSghc-9.4.2-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHSghc-9.4.2-ghc9.4.2.so (0x00007fc0e0bdd000)
	libHSterminfo-0.4.1.5-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHSterminfo-0.4.1.5-ghc9.4.2.so (0x00007fc0e0b9c000)
	libHSprocess-1.6.15.0-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHSprocess-1.6.15.0-ghc9.4.2.so (0x00007fc0e0b5b000)
	libHShpc-0.6.1.0-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHShpc-0.6.1.0-ghc9.4.2.so (0x00007fc0e0b24000)
	libHSghci-9.4.2-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHSghci-9.4.2-ghc9.4.2.so (0x00007fc0e08ae000)
	libHSghc-heap-9.4.2-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHSghc-heap-9.4.2-ghc9.4.2.so (0x00007fc0e07e7000)
	libHSghc-boot-9.4.2-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHSghc-boot-9.4.2-ghc9.4.2.so (0x00007fc0e0714000)
	libHSbinary-0.8.9.1-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHSbinary-0.8.9.1-ghc9.4.2.so (0x00007fc0e064a000)
	libHSexceptions-0.10.5-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHSexceptions-0.10.5-ghc9.4.2.so (0x00007fc0e060e000)
	libHSstm-2.5.1.0-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHSstm-2.5.1.0-ghc9.4.2.so (0x00007fc0e05ec000)
	libHSmtl-2.2.2-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHSmtl-2.2.2-ghc9.4.2.so (0x00007fc0e05b6000)
	libHStransformers-0.5.6.2-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHStransformers-0.5.6.2-ghc9.4.2.so (0x00007fc0e0468000)
	libHSdirectory-1.3.7.1-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHSdirectory-1.3.7.1-ghc9.4.2.so (0x00007fc0e0403000)
	libHSunix-2.7.3-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHSunix-2.7.3-ghc9.4.2.so (0x00007fc0e031d000)
	libHStime-1.12.2-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHStime-1.12.2-ghc9.4.2.so (0x00007fc0e0180000)
	libHSfilepath-1.4.2.2-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHSfilepath-1.4.2.2-ghc9.4.2.so (0x00007fc0e015a000)
	libHScontainers-0.6.6-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHScontainers-0.6.6-ghc9.4.2.so (0x00007fc0dfda0000)
	libHSbytestring-0.11.3.1-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHSbytestring-0.11.3.1-ghc9.4.2.so (0x00007fc0dfc2e000)
	libHStemplate-haskell-2.19.0.0-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHStemplate-haskell-2.19.0.0-ghc9.4.2.so (0x00007fc0df852000)
	libHSpretty-1.1.3.6-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHSpretty-1.1.3.6-ghc9.4.2.so (0x00007fc0df7da000)
	libHSghc-boot-th-9.4.2-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHSghc-boot-th-9.4.2-ghc9.4.2.so (0x00007fc0df79a000)
	libHSdeepseq-1.4.8.0-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHSdeepseq-1.4.8.0-ghc9.4.2.so (0x00007fc0df77e000)
	libHSarray-0.5.4.0-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHSarray-0.5.4.0-ghc9.4.2.so (0x00007fc0df6f6000)
	libHSbase-4.17.0.0-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHSbase-4.17.0.0-ghc9.4.2.so (0x00007fc0dec3e000)
	libHSghc-bignum-1.3-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHSghc-bignum-1.3-ghc9.4.2.so (0x00007fc0debeb000)
	libHSghc-prim-0.9.0-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHSghc-prim-0.9.0-ghc9.4.2.so (0x00007fc0de6ee000)
	libHSrts-1.0.2_thr-ghc9.4.2.so => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libHSrts-1.0.2_thr-ghc9.4.2.so (0x00007fc0de634000)
	libffi.so.8 => /home/ghc/.ghcup/ghc/9.4.2/lib/ghc-9.4.2/bin/../lib/x86_64-linux-ghc-9.4.2/libffi.so.8 (0x00007fc0de425000)
	libtinfo.so.5 => /lib64/libtinfo.so.5 (0x00007fc0de1fb000)
	librt.so.1 => /lib64/librt.so.1 (0x00007fc0ddff3000)
	libutil.so.1 => /lib64/libutil.so.1 (0x00007fc0dddf0000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007fc0ddbec000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fc0dd9ce000)
	libgmp.so.10 => /lib64/libgmp.so.10 (0x00007fc0dd756000)
	libc.so.6 => /lib64/libc.so.6 (0x00007fc0dd3a0000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fc0e69d5000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fc0dd187000)
```

