### PR TITLE
Upgrade to newest ghcup-hs master

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -7,7 +7,7 @@ package ghcup
 source-repository-package
   type: git
   location: https://github.com/haskell/ghcup-hs.git
-  tag: v0.1.19.2
+  tag: a2a605ad892675d317e8415522e2cf12d5e35571
 
 constraints: http-io-streams -brotli,
              any.aeson >= 2.0.1.0

--- a/ghcup-gen/Generate.hs
+++ b/ghcup-gen/Generate.hs
@@ -157,7 +157,7 @@ generateTable output = do
     liftIO $ hPutStrLn handle $ "<table>"
     liftIO $ hPutStrLn handle $ "<thead><tr><th>" <> show tool <> " Version</th><th>Tags</th></tr></thead>"
     liftIO $ hPutStrLn handle $ "<tbody>"
-    vers <- reverse <$> listVersions (Just tool) Nothing
+    vers <- reverse <$> listVersions (Just tool) [] False False (Nothing, Nothing)
     forM_ (filter (\ListResult{..} -> not lStray) vers) $ \ListResult{..} -> do
       liftIO $ hPutStrLn handle $
           "<tr><td>"


### PR DESCRIPTION
Needed to upgrade ghcup-metadata to use newest `master` for upcoming changes there.

This PR upgrades the codebase to use newest master commit of `ghcup-hs`,  partially in response to https://github.com/haskell/ghcup-hs/issues/777

Changes include:- 

* Upgrades ghcup-metadata to use newest master branch commit.
  - updates cabal.project

* fixes breaking changes when upgrading to new ghcup-hs, following changes were made to `ghcup-gen` to make it build with new `ghcup-hs` library.
  - `listVersions` function changed type-signature, fixed useages
  - Needed some `GHCTargetVersion` -> `Version` type conversions to build.