### PR TITLE
New Docs generation code - Take OS/Distro version into account when listing dependencies.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -7,7 +7,7 @@ package ghcup
 source-repository-package
   type: git
   location: https://github.com/haskell/ghcup-hs.git
-  tag: a2a605ad892675d317e8415522e2cf12d5e35571
+  tag: fd6ff9f8ece147bb4527843822462c72824e8ba7
 
 constraints: http-io-streams -brotli,
              any.aeson >= 2.0.1.0

--- a/ghcup-gen/Main.hs
+++ b/ghcup-gen/Main.hs
@@ -209,7 +209,7 @@ main = do
           ValidateTarballs vopts tarballFilter -> withValidateYamlOpts vopts (validateTarballs tarballFilter)
           GenerateHlsGhc vopts format output -> withValidateYamlOpts vopts (generateHLSGhc format output)
           GenerateToolTable vopts output -> withValidateYamlOpts vopts (generateTable output)
-          GenerateSystemDepsInfo vopts output -> withValidateYamlOpts vopts (generateSystemInfo output)
+          GenerateSystemDepsInfo vopts output -> withValidateYamlOpts vopts (generateSystemInfoWithDistroVersion output)
   pure ()
 
  where


### PR DESCRIPTION
PR in response to and fixes https://github.com/haskell/ghcup-hs/issues/777 .

This is final PR in the series of 3 PRs addressing haskell/ghcup-hs#777

Prev PRs:-
- https://github.com/haskell/ghcup-metadata/pull/103
- https://github.com/haskell/ghcup-hs/pull/868

### This PR :- 
* Adds new docs generation code that takes OS/distro version into
  account when generating dependency list for that platform.

* Moves away from old hard-coded approach to a new approach
  that reads Distro/OS version from the yaml file and
  generates the dependecy list taking distro/OS versions
  from the yaml file into account
  
* Upgrades `ghcup-hs` dependecy version/hash in `cabal.project` file. The new version has the `Pretty` instances needed to pretty-print version numbers here.

* Fixes a very commonly reported bug that trips up new users - https://github.com/haskell/ghcup-hs/issues/777

### Screenshots

Below are the visual depictions of the before and after of the documentation code that is generated. 
First is current version, which needed fixing and the second screenshot shows the output generated by the new fixed version. 
These are sample outputs, just for illustration. Final output should match the current styles.

#### Old (current status quo)

- Hardcoded OS/Distro logic.
- Does not take OS/Distro version into account when listing dependencies to be installed.

![Screenshot from 2023-09-02 21-17-05](https://github.com/haskell/ghcup-metadata/assets/12858057/cca6f17c-11e1-4382-9f63-8ba84516ec1d)

#### New (fixed)
- Takes Distro or OS version into account when listing OS/Distro dependencies.
- Reads version from yaml file dynamically, *not* hardcoded, any change in the yaml files will be reflected in the docs accordingly and immediately. 

![Screenshot from 2023-09-02 21-17-34](https://github.com/haskell/ghcup-metadata/assets/12858057/e2c4e349-f6da-491f-80f9-6e8a338f7832)
