### PR TITLE
Fix #131 Add Stack 2.13.1 ('official' bindists only)

### DIFF
--- a/ghcup-0.0.7.yaml
+++ b/ghcup-0.0.7.yaml
@@ -5756,8 +5756,7 @@ ghcupDownloads:
               dlUri: https://downloads.haskell.org/ghcup/unofficial-bindists/stack/2.9.3/stack-2.9.3-osx-aarch64.tar.gz
               dlHash: a56d2cd37611eccf00ab8df38c3718923cf5677f3aeacd250394e79b676dcb98
     2.11.1:
-      viTags:
-        - Latest
+      viTags: []
       viChangeLog: https://github.com/commercialhaskell/stack/blob/master/ChangeLog.md#v2111---2023-05-18
       viPostInstall: *stack-post
       viArch:
@@ -5797,5 +5796,49 @@ ghcupDownloads:
             unknown_versioning:
               dlUri: https://downloads.haskell.org/ghcup/unofficial-bindists/stack/2.11.1/stack-2.11.1-osx-aarch64.tar.gz
               dlHash: 3ea56c5885c9c6d7e2dce927e44f48f6024a4a5a039f7acad79b19654a6f95b5
+              dlSubdir:
+                RegexDir: "stack-.*"
+    2.13.1:
+      viTags:
+        - Latest
+      viChangeLog: https://github.com/commercialhaskell/stack/blob/master/ChangeLog.md#v2131---2023-09-29
+      viPostInstall: *stack-post
+      viArch:
+        A_64:
+          Linux_UnknownLinux:
+            unknown_versioning: &stack-2131-64
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v2.13.1/stack-2.13.1-linux-x86_64.tar.gz
+              dlHash: 45281bb2385e928916ec8bcbc7ab790ce8721bbf805f3d0752544ada22ad5ea3
+              dlSubdir:
+                RegexDir: "stack-.*"
+          Darwin:
+            unknown_versioning:
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v2.13.1/stack-2.13.1-osx-x86_64.tar.gz
+              dlHash: b7d46382edb17230d21943844550d3aaeacee8b6fb1fcc7980ca59bee500b2a5
+              dlSubdir:
+                RegexDir: "stack-.*"
+          Windows:
+            unknown_versioning:
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v2.13.1/stack-2.13.1-windows-x86_64.tar.gz
+              dlHash: 728be2371e257c6960341167192fa704ff1f92ab61657dd4781710a257fae7c1
+              dlSubdir:
+                RegexDir: "stack-.*"
+        # FreeBSD:
+        #   unknown_versioning:
+        #     dlUri: https://downloads.haskell.org/ghcup/unofficial-bindists/stack/2.13.1/stack-2.13.1-freebsd-x86_64.tar.xz
+        #     dlHash: <replace_me>
+          Linux_Alpine:
+            unknown_versioning: *stack-2131-64
+        A_ARM64:
+          Linux_UnknownLinux:
+            unknown_versioning:
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v2.13.1/stack-2.13.1-linux-aarch64.tar.gz
+              dlHash: 37b1dbf39131eea629a6e3685fd1153fdfd2f0cd2179db92bb33784987b4ddb8
+              dlSubdir:
+                RegexDir: "stack-.*"
+          Darwin:
+            unknown_versioning:
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v2.13.1/stack-2.13.1-osx-aarch64.tar.gz
+              dlHash: 18ececd7112b1aad01ab0f88cb68ae63f2dc74aa9b8b5319828979f43cba9907
               dlSubdir:
                 RegexDir: "stack-.*"


### PR DESCRIPTION
I have left a place holder for the 'unofficial' FreeBSD that has previously been provided by the GHCup project. (Stack 2.13.1 now has an 'official' binary distribution for macOS/AArch64.)