### PR TITLE
fix incorrect link to 32-bit (A_32) Linux_Debian cabal-install for version 3.10.2.0

### DIFF
--- a/ghcup-0.0.7.yaml
+++ b/ghcup-0.0.7.yaml
@@ -4494,7 +4494,7 @@ ghcupDownloads:
             unknown_versioning: *cabal-31020-32
           Linux_Debian:
             '( >= 9 )':
-              dlUri: https://downloads.haskell.org/cabal/cabal-install-3.10.2.0/cabal-install-3.10.2.0-x86_64-linux-deb9.tar.xz
+              dlUri: https://downloads.haskell.org/cabal/cabal-install-3.10.2.0/cabal-install-3.10.2.0-i386-linux-deb9.tar.xz
               dlHash: 2b26d2cb67f1ba3561509fbccc30810ccc1c5032238fca00666e3dcd03e941a8
             unknown_versioning: *cabal-31020-32
         A_ARM64:


### PR DESCRIPTION
Working on https://github.com/haskell/cabal/issues/9298 made me notice the incorrect link here, so there's already some good coming out of it : )

* The link for 32-bit (A_32) Linux_Debian cabal-install under version 3.10.2.0 points to the 64-bit (x64-64) version.

* The hash for this however was found to be correct here, so it was left unchanged.

* Fixes the link to point to the correct 32-bit (i386) version.