### PR TITLE
Use the righ ghc-9.4.8 tarball for Debian Linux without version

### DIFF
--- a/ghcup-0.0.7.yaml
+++ b/ghcup-0.0.7.yaml
@@ -3637,7 +3637,7 @@ ghcupDownloads:
               dlUri: https://downloads.haskell.org/~ghc/9.4.8/ghc-9.4.8-x86_64-deb11-linux.tar.xz
               dlSubdir: ghc-9.4.8-x86_64-unknown-linux
               dlHash: 2743629d040f3213499146cb5154621d6f25e85271019afc9b9009e04d66bf6c
-            unknown_versioning: *ghc-948-64-deb9
+            unknown_versioning: *ghc-948-64-deb11
           Linux_Ubuntu:
             unknown_versioning: *ghc-948-64-deb10
             '( >= 16 && < 19 )': *ghc-948-64-deb9

--- a/ghcup-0.0.8.yaml
+++ b/ghcup-0.0.8.yaml
@@ -3637,7 +3637,7 @@ ghcupDownloads:
               dlUri: https://downloads.haskell.org/~ghc/9.4.8/ghc-9.4.8-x86_64-deb11-linux.tar.xz
               dlSubdir: ghc-9.4.8-x86_64-unknown-linux
               dlHash: 2743629d040f3213499146cb5154621d6f25e85271019afc9b9009e04d66bf6c
-            unknown_versioning: *ghc-948-64-deb9
+            unknown_versioning: *ghc-948-64-deb11
           Linux_Ubuntu:
             unknown_versioning: *ghc-948-64-deb10
             '( >= 16 && < 19 )': *ghc-948-64-deb9

--- a/ghcup-vanilla-0.0.7.yaml
+++ b/ghcup-vanilla-0.0.7.yaml
@@ -3461,7 +3461,7 @@ ghcupDownloads:
               dlUri: https://downloads.haskell.org/~ghc/9.4.8/ghc-9.4.8-x86_64-deb11-linux.tar.xz
               dlSubdir: ghc-9.4.8-x86_64-unknown-linux
               dlHash: 2743629d040f3213499146cb5154621d6f25e85271019afc9b9009e04d66bf6c
-            unknown_versioning: *ghc-948-64-deb9
+            unknown_versioning: *ghc-948-64-deb11
           Linux_Ubuntu:
             unknown_versioning: *ghc-948-64-deb10
             '( >= 16 && < 19 )': *ghc-948-64-deb9
@@ -5865,4 +5865,3 @@ ghcupDownloads:
               dlHash: 18ececd7112b1aad01ab0f88cb68ae63f2dc74aa9b8b5319828979f43cba9907
               dlSubdir:
                 RegexDir: "stack-.*"
-

--- a/ghcup-vanilla-0.0.8.yaml
+++ b/ghcup-vanilla-0.0.8.yaml
@@ -3461,7 +3461,7 @@ ghcupDownloads:
               dlUri: https://downloads.haskell.org/~ghc/9.4.8/ghc-9.4.8-x86_64-deb11-linux.tar.xz
               dlSubdir: ghc-9.4.8-x86_64-unknown-linux
               dlHash: 2743629d040f3213499146cb5154621d6f25e85271019afc9b9009e04d66bf6c
-            unknown_versioning: *ghc-948-64-deb9
+            unknown_versioning: *ghc-948-64-deb11
           Linux_Ubuntu:
             unknown_versioning: *ghc-948-64-deb10
             '( >= 16 && < 19 )': *ghc-948-64-deb9
@@ -5865,4 +5865,3 @@ ghcupDownloads:
               dlHash: 18ececd7112b1aad01ab0f88cb68ae63f2dc74aa9b8b5319828979f43cba9907
               dlSubdir:
                 RegexDir: "stack-.*"
-


### PR DESCRIPTION
I think we have the wrong tarball specified for ghc-9.4.8 for Debian GNU/Linux (x64) when the version of the distro is unknown. We use `deb11` since version 9.4.1:
```shell
$ cat ghcup-0.0.8.yaml | yq '.ghcupDownloads .GHC | map_values (.viArch.A_64.Linux_Debian.unknown_versioning)' | tail 
9.4.3: *ghc-943-64-deb11
9.4.4: *ghc-944-64-deb11
9.4.5: *ghc-945-64-deb11
9.4.6: *ghc-946-64-deb11
9.4.7: *ghc-947-64-deb11
9.4.8: *ghc-948-64-deb9
9.6.1: *ghc-961-64-deb11
9.6.2: *ghc-962-64-deb11
9.6.3: *ghc-963-64-deb11
9.8.1: *ghc981-x86_64-deb11
```