### PR TITLE
Add Stack 2.15.0.1 pre-release to GHCup metadata

### DIFF
--- a/ghcup-prereleases-0.0.8.yaml
+++ b/ghcup-prereleases-0.0.8.yaml
@@ -1490,7 +1490,8 @@ ghcupDownloads:
                 RegexDir: "stack-.*"
     2.13.0.1:
       viTags:
-        - LatestPrerelease
+        - Prerelease
+        - old
       viChangeLog: https://github.com/commercialhaskell/stack/blob/rc/v2.13/ChangeLog.md#v21301-release-candidate
       viArch:
         A_64:
@@ -1525,5 +1526,44 @@ ghcupDownloads:
             unknown_versioning:
               dlUri: https://github.com/commercialhaskell/stack/releases/download/rc/v2.13.0.1/stack-2.13.0.1-osx-aarch64.tar.gz
               dlHash: 9c3b957c7c8b1c5c09e0251907372563b48d5869c31e35be43916736f679535d
+              dlSubdir:
+                RegexDir: "stack-.*"
+    2.15.0.1:
+      viTags:
+        - LatestPrerelease
+      viChangeLog: https://github.com/commercialhaskell/stack/blob/rc/v2.15/ChangeLog.md#v21501-release-candidate---2024-01-27
+      viArch:
+        A_64:
+          Linux_UnknownLinux:
+            unknown_versioning: &stack-21501-64
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/rc/v2.15.0.1/stack-2.15.0.1-linux-x86_64.tar.gz
+              dlHash: f59b41418b2c12f1ac643b1c8c8caa9e4936d2c5a35593e67d7243d97a1de948
+              dlSubdir:
+                RegexDir: "stack-.*"
+          Darwin:
+            unknown_versioning:
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/rc/v2.15.0.1/stack-2.15.0.1-osx-x86_64.tar.gz
+              dlHash: 7cbdb14060f19eefeff56d7d4887db0a1c5ade6bcd1d05abff5e5d819e4945f0
+              dlSubdir:
+                RegexDir: "stack-.*"
+          Windows:
+            unknown_versioning:
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/rc/v2.15.0.1/stack-2.15.0.1-windows-x86_64.tar.gz
+              dlHash: f23f45c47228f98df47da4613df87f2ee5b55edcf4e466a1d7b3aced2161a7d0
+              dlSubdir:
+                RegexDir: "stack-.*"
+          Linux_Alpine:
+            unknown_versioning: *stack-21501-64
+        A_ARM64:
+          Linux_UnknownLinux:
+            unknown_versioning:
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/rc/v2.15.0.1/stack-2.15.0.1-linux-aarch64.tar.gz
+              dlHash: 087b9b02e318ba28cbbd13b512da0758e2522016e260e2b2a3d076148225972e
+              dlSubdir:
+                RegexDir: "stack-.*"
+          Darwin:
+            unknown_versioning:
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/rc/v2.15.0.1/stack-2.15.0.1-osx-aarch64.tar.gz
+              dlHash: 2c5fb2efcf646287aa91d3a1d6f8d08129734bc3e0c50d6756aba81b9309d7c1
               dlSubdir:
                 RegexDir: "stack-.*"


### PR DESCRIPTION
See https://github.com/commercialhaskell/stack/issues/6397#issuecomment-1913590580. However, I assumed, like Stack 2.13.0.1 before, it was `prereleases` that I should target.