### PR TITLE
Bump recommended GHC version in the vanilla channel

### DIFF
--- a/ghcup-vanilla-0.0.7.yaml
+++ b/ghcup-vanilla-0.0.7.yaml
@@ -3730,7 +3730,6 @@ ghcupDownloads:
         dlSubdir: ghc-9.6.2
         dlUri: https://downloads.haskell.org/~ghc/9.6.2/ghc-9.6.2-src.tar.xz
       viTags:
-      - Recommended
       - base-4.18.0.0
       viTestDL:
         dlHash: e4ffbc2d6db720fba30f8e7e12214522c470d1cfc0ee69f7997782b0ae20abbf
@@ -3927,6 +3926,7 @@ ghcupDownloads:
         dlSubdir: ghc-9.6.4
         dlUri: https://downloads.haskell.org/~ghc/9.6.4/ghc-9.6.4-src.tar.xz
       viTags:
+      - Recommended
       - base-4.18.2.0
       viTestDL:
         dlHash: 6e13282fbebffdbfa0a49889437444c9a90cfe5760c47969cd4245854c338d73

--- a/ghcup-vanilla-0.0.8.yaml
+++ b/ghcup-vanilla-0.0.8.yaml
@@ -3730,7 +3730,6 @@ ghcupDownloads:
         dlSubdir: ghc-9.6.2
         dlUri: https://downloads.haskell.org/~ghc/9.6.2/ghc-9.6.2-src.tar.xz
       viTags:
-      - Recommended
       - base-4.18.0.0
       viTestDL:
         dlHash: e4ffbc2d6db720fba30f8e7e12214522c470d1cfc0ee69f7997782b0ae20abbf
@@ -3927,6 +3926,7 @@ ghcupDownloads:
         dlSubdir: ghc-9.6.4
         dlUri: https://downloads.haskell.org/~ghc/9.6.4/ghc-9.6.4-src.tar.xz
       viTags:
+      - Recommended
       - base-4.18.2.0
       viTestDL:
         dlHash: 6e13282fbebffdbfa0a49889437444c9a90cfe5760c47969cd4245854c338d73


### PR DESCRIPTION
That should unbreak our release CI https://github.com/haskell/haskell-language-server/issues/4120