### PR TITLE
Fix FreeBSD "pkg-config" spelling

### DIFF
--- a/ghcup-0.0.7.yaml
+++ b/ghcup-0.0.7.yaml
@@ -221,7 +221,7 @@ toolRequirements:
           - gmake
           - ncurses
           - perl5
-          - pkg-confg
+          - pkg-config
           - libffi
           - libiconv
           notes: ''

--- a/ghcup-0.0.8.yaml
+++ b/ghcup-0.0.8.yaml
@@ -265,7 +265,7 @@ toolRequirements:
           - gmake
           - ncurses
           - perl5
-          - pkg-confg
+          - pkg-config
           - libffi
           - libiconv
           notes: ''

--- a/ghcup-vanilla-0.0.7.yaml
+++ b/ghcup-vanilla-0.0.7.yaml
@@ -221,7 +221,7 @@ toolRequirements:
           - gmake
           - ncurses
           - perl5
-          - pkg-confg
+          - pkg-config
           - libffi
           - libiconv
           notes: ''

--- a/ghcup-vanilla-0.0.8.yaml
+++ b/ghcup-vanilla-0.0.8.yaml
@@ -265,7 +265,7 @@ toolRequirements:
           - gmake
           - ncurses
           - perl5
-          - pkg-confg
+          - pkg-config
           - libffi
           - libiconv
           notes: ''


### PR DESCRIPTION
There is no such package "pkg-confg", it should be named "pkg-config" (like on other unix-like OSes)