### PR TITLE
The recommended HLS version supports GHC 9.6.7

### DIFF
--- a/ghcup-0.0.9.yaml
+++ b/ghcup-0.0.9.yaml
@@ -4523,9 +4523,6 @@ ghcupDownloads:
         dlSubdir: ghc-9.6.7
         dlUri: https://downloads.haskell.org/~ghc/9.6.7/ghc-9.6.7-src.tar.xz
       viChangeLog: https://downloads.haskell.org/~ghc/9.6.7/docs/users_guide/9.6.7-notes.html
-      viPostInstall: |
-        HLS is not supported for 9.6.7 yet. To build from source, run:
-          ghcup compile hls -g 2.9.0.1 --ghc 9.6.7 --cabal-update -- --constraint="ghc-lib-parser == 9.8.5.20250214" --index-state="2025-02-14T12:50:38Z"
       viArch:
         A_32:
           Linux_Debian:


### PR DESCRIPTION
On installing the 'recommended' GHC version 9.6.7, GHCup prints a message that HLS does not yet support this version. However, it does, and you do not even need the latest HLS version for it -- the current 'recommended' (2.10.0.0) has a pre-built binary for 9.6.7. The postinstall note is old, and can be removed, I think.