### PR TITLE
Fix Windows download URL for ormolu

### DIFF
--- a/ghcup-3rdparty-0.1.0.yaml
+++ b/ghcup-3rdparty-0.1.0.yaml
@@ -81,7 +81,7 @@ ghcupDownloads:
                   preserveMtimes: false
             Windows:
               unknown_versioning:
-                dlUri: https://github.com/ndmitchell/hlint/releases/download/v3.10/hlint-3.10-x86_64-windows.zip
+                dlUri: https://github.com/tweag/ormolu/releases/download/0.8.0.2/ormolu-x86_64-windows.zip
                 dlHash: 3e484422d68260083fcb7841433a9fa172ff01131f8610d750c1902fba4f2b7e
                 dlInstallSpec: &ormolu-install-spec1
                   exeRules:


### PR DESCRIPTION
- [x] I have read https://github.com/haskell/ghcup-metadata?tab=readme-ov-file#contributions and https://www.haskell.org/ghcup/dev/
- [x] I did not use an LLM to generate this patch or parts of it
- [x] I understand that PRs may take 1-2 weeks to be reviewed and merged

---

In `ghcup-3rdparty-0.1.0.yaml`, the Windows download link for Ormolu somehow points to the release of `hlint`:
https://github.com/haskell/ghcup-metadata/blob/0e2f1b18283ebedf120b54b68c17ba692c1debf0/ghcup-3rdparty-0.1.0.yaml#L82-L85
I corrected the link in this PR. The hash is correct, though (correct in the sense that it matches the actual ormolu archive).
