### PR TITLE
Add metadata on release of Stack 3.11.1

### DIFF
--- a/ghcup-vanilla-0.0.7.yaml
+++ b/ghcup-vanilla-0.0.7.yaml
@@ -7660,9 +7660,7 @@ ghcupDownloads:
           Linux_Alpine:
             unknown_versioning: *stack-391-arm64
     3.9.3:
-      viTags:
-        - Latest
-        - Recommended
+      viTags: []
       viChangeLog: https://github.com/commercialhaskell/stack/blob/master/ChangeLog.md#v393---2026-02-19
       viPostInstall: *stack-post
       viArch:
@@ -7706,3 +7704,50 @@ ghcupDownloads:
                 RegexDir: "stack-.*"
           Linux_Alpine:
             unknown_versioning: *stack-393-arm64
+    3.11.1:
+      viTags:
+        - Latest
+        - Recommended
+      viChangeLog: https://github.com/commercialhaskell/stack/blob/master/ChangeLog.md#v3111---2026-06-13
+      viPostInstall: *stack-post
+      viArch:
+        A_64:
+          Linux_UnknownLinux:
+            unknown_versioning: &stack-3111-64
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v3.11.1/stack-3.11.1-linux-x86_64.tar.gz
+              dlHash: 1fda71e657cd8d355625cc66b61b352699279dfee2664c014a392163bd19a952
+              dlSubdir:
+                RegexDir: "stack-.*"
+          Darwin:
+            unknown_versioning:
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v3.11.1/stack-3.11.1-osx-x86_64.tar.gz
+              dlHash: 603db63eef6246b02dd042e446686f61e3410ee9ef73cb3838314e24468fb290
+              dlSubdir:
+                RegexDir: "stack-.*"
+          Windows:
+            unknown_versioning:
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v3.11.1/stack-3.11.1-windows-x86_64.tar.gz
+              dlHash: 333526925874611fbb9df68825e2980b9623bf1f0cfafa7334f210239b9c4834
+              dlSubdir:
+                RegexDir: "stack-.*"
+          # FreeBSD:
+          #   unknown_versioning:
+          #     dlUri: https://downloads.haskell.org/ghcup/unofficial-bindists/stack/3.11.1/stack-3.11.1-freebsd-x86_64.tar.xz
+          #     dlHash: <replace_me>
+          Linux_Alpine:
+            unknown_versioning: *stack-3111-64
+        A_ARM64:
+          Linux_UnknownLinux:
+            unknown_versioning: &stack-3111-arm64
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v3.11.1/stack-3.11.1-linux-aarch64.tar.gz
+              dlHash: 1617ae9976a5cd38ad4daec583b026b589eb45d5482afb045cd4ca8c8d0de6d0
+              dlSubdir:
+                RegexDir: "stack-.*"
+          Darwin:
+            unknown_versioning:
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v3.11.1/stack-3.11.1-osx-aarch64.tar.gz
+              dlHash: 652572ddf74616a7975892de9c61a9e5e6b5979db4f9b00fcd659ac6a15d7330
+              dlSubdir:
+                RegexDir: "stack-.*"
+          Linux_Alpine:
+            unknown_versioning: *stack-3111-arm64

--- a/ghcup-vanilla-0.0.8.yaml
+++ b/ghcup-vanilla-0.0.8.yaml
@@ -8882,9 +8882,7 @@ ghcupDownloads:
           Linux_Alpine:
             unknown_versioning: *stack-391-arm64
     3.9.3:
-      viTags:
-        - Latest
-        - Recommended
+      viTags: []
       viChangeLog: https://github.com/commercialhaskell/stack/blob/master/ChangeLog.md#v393---2026-02-19
       viPostInstall: *stack-post
       viArch:
@@ -8928,3 +8926,50 @@ ghcupDownloads:
                 RegexDir: "stack-.*"
           Linux_Alpine:
             unknown_versioning: *stack-393-arm64
+    3.11.1:
+      viTags:
+        - Latest
+        - Recommended
+      viChangeLog: https://github.com/commercialhaskell/stack/blob/master/ChangeLog.md#v3111---2026-06-13
+      viPostInstall: *stack-post
+      viArch:
+        A_64:
+          Linux_UnknownLinux:
+            unknown_versioning: &stack-3111-64
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v3.11.1/stack-3.11.1-linux-x86_64.tar.gz
+              dlHash: 1fda71e657cd8d355625cc66b61b352699279dfee2664c014a392163bd19a952
+              dlSubdir:
+                RegexDir: "stack-.*"
+          Darwin:
+            unknown_versioning:
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v3.11.1/stack-3.11.1-osx-x86_64.tar.gz
+              dlHash: 603db63eef6246b02dd042e446686f61e3410ee9ef73cb3838314e24468fb290
+              dlSubdir:
+                RegexDir: "stack-.*"
+          Windows:
+            unknown_versioning:
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v3.11.1/stack-3.11.1-windows-x86_64.tar.gz
+              dlHash: 333526925874611fbb9df68825e2980b9623bf1f0cfafa7334f210239b9c4834
+              dlSubdir:
+                RegexDir: "stack-.*"
+          # FreeBSD:
+          #   unknown_versioning:
+          #     dlUri: https://downloads.haskell.org/ghcup/unofficial-bindists/stack/3.11.1/stack-3.11.1-freebsd-x86_64.tar.xz
+          #     dlHash: <replace_me>
+          Linux_Alpine:
+            unknown_versioning: *stack-3111-64
+        A_ARM64:
+          Linux_UnknownLinux:
+            unknown_versioning: &stack-3111-arm64
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v3.11.1/stack-3.11.1-linux-aarch64.tar.gz
+              dlHash: 1617ae9976a5cd38ad4daec583b026b589eb45d5482afb045cd4ca8c8d0de6d0
+              dlSubdir:
+                RegexDir: "stack-.*"
+          Darwin:
+            unknown_versioning:
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v3.11.1/stack-3.11.1-osx-aarch64.tar.gz
+              dlHash: 652572ddf74616a7975892de9c61a9e5e6b5979db4f9b00fcd659ac6a15d7330
+              dlSubdir:
+                RegexDir: "stack-.*"
+          Linux_Alpine:
+            unknown_versioning: *stack-3111-arm64

--- a/ghcup-vanilla-0.0.9.yaml
+++ b/ghcup-vanilla-0.0.9.yaml
@@ -9890,9 +9890,7 @@ ghcupDownloads:
           Linux_Alpine:
             unknown_versioning: *stack-391-arm64
     3.9.3:
-      viTags:
-        - Latest
-        - Recommended
+      viTags: []
       viChangeLog: https://github.com/commercialhaskell/stack/blob/master/ChangeLog.md#v393---2026-02-19
       viPostInstall: *stack-post
       viArch:
@@ -9936,3 +9934,50 @@ ghcupDownloads:
                 RegexDir: "stack-.*"
           Linux_Alpine:
             unknown_versioning: *stack-393-arm64
+    3.11.1:
+      viTags:
+        - Latest
+        - Recommended
+      viChangeLog: https://github.com/commercialhaskell/stack/blob/master/ChangeLog.md#v3111---2026-06-13
+      viPostInstall: *stack-post
+      viArch:
+        A_64:
+          Linux_UnknownLinux:
+            unknown_versioning: &stack-3111-64
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v3.11.1/stack-3.11.1-linux-x86_64.tar.gz
+              dlHash: 1fda71e657cd8d355625cc66b61b352699279dfee2664c014a392163bd19a952
+              dlSubdir:
+                RegexDir: "stack-.*"
+          Darwin:
+            unknown_versioning:
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v3.11.1/stack-3.11.1-osx-x86_64.tar.gz
+              dlHash: 603db63eef6246b02dd042e446686f61e3410ee9ef73cb3838314e24468fb290
+              dlSubdir:
+                RegexDir: "stack-.*"
+          Windows:
+            unknown_versioning:
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v3.11.1/stack-3.11.1-windows-x86_64.tar.gz
+              dlHash: 333526925874611fbb9df68825e2980b9623bf1f0cfafa7334f210239b9c4834
+              dlSubdir:
+                RegexDir: "stack-.*"
+          # FreeBSD:
+          #   unknown_versioning:
+          #     dlUri: https://downloads.haskell.org/ghcup/unofficial-bindists/stack/3.11.1/stack-3.11.1-freebsd-x86_64.tar.xz
+          #     dlHash: <replace_me>
+          Linux_Alpine:
+            unknown_versioning: *stack-3111-64
+        A_ARM64:
+          Linux_UnknownLinux:
+            unknown_versioning: &stack-3111-arm64
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v3.11.1/stack-3.11.1-linux-aarch64.tar.gz
+              dlHash: 1617ae9976a5cd38ad4daec583b026b589eb45d5482afb045cd4ca8c8d0de6d0
+              dlSubdir:
+                RegexDir: "stack-.*"
+          Darwin:
+            unknown_versioning:
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v3.11.1/stack-3.11.1-osx-aarch64.tar.gz
+              dlHash: 652572ddf74616a7975892de9c61a9e5e6b5979db4f9b00fcd659ac6a15d7330
+              dlSubdir:
+                RegexDir: "stack-.*"
+          Linux_Alpine:
+            unknown_versioning: *stack-3111-arm64

--- a/ghcup-vanilla-0.1.0.yaml
+++ b/ghcup-vanilla-0.1.0.yaml
@@ -10332,9 +10332,7 @@ ghcupDownloads:
           Linux_Alpine:
             unknown_versioning: *stack-391-arm64
     3.9.3:
-      viTags:
-        - Latest
-        - Recommended
+      viTags: []
       viChangeLog: https://github.com/commercialhaskell/stack/blob/master/ChangeLog.md#v393---2026-02-19
       viPostInstall: *stack-post
       viArch:
@@ -10378,3 +10376,50 @@ ghcupDownloads:
                 RegexDir: "stack-.*"
           Linux_Alpine:
             unknown_versioning: *stack-393-arm64
+    3.11.1:
+      viTags:
+        - Latest
+        - Recommended
+      viChangeLog: https://github.com/commercialhaskell/stack/blob/master/ChangeLog.md#v3111---2026-06-13
+      viPostInstall: *stack-post
+      viArch:
+        A_64:
+          Linux_UnknownLinux:
+            unknown_versioning: &stack-3111-64
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v3.11.1/stack-3.11.1-linux-x86_64.tar.gz
+              dlHash: 1fda71e657cd8d355625cc66b61b352699279dfee2664c014a392163bd19a952
+              dlSubdir:
+                RegexDir: "stack-.*"
+          Darwin:
+            unknown_versioning:
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v3.11.1/stack-3.11.1-osx-x86_64.tar.gz
+              dlHash: 603db63eef6246b02dd042e446686f61e3410ee9ef73cb3838314e24468fb290
+              dlSubdir:
+                RegexDir: "stack-.*"
+          Windows:
+            unknown_versioning:
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v3.11.1/stack-3.11.1-windows-x86_64.tar.gz
+              dlHash: 333526925874611fbb9df68825e2980b9623bf1f0cfafa7334f210239b9c4834
+              dlSubdir:
+                RegexDir: "stack-.*"
+          # FreeBSD:
+          #   unknown_versioning:
+          #     dlUri: https://downloads.haskell.org/ghcup/unofficial-bindists/stack/3.11.1/stack-3.11.1-freebsd-x86_64.tar.xz
+          #     dlHash: <replace_me>
+          Linux_Alpine:
+            unknown_versioning: *stack-3111-64
+        A_ARM64:
+          Linux_UnknownLinux:
+            unknown_versioning: &stack-3111-arm64
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v3.11.1/stack-3.11.1-linux-aarch64.tar.gz
+              dlHash: 1617ae9976a5cd38ad4daec583b026b589eb45d5482afb045cd4ca8c8d0de6d0
+              dlSubdir:
+                RegexDir: "stack-.*"
+          Darwin:
+            unknown_versioning:
+              dlUri: https://github.com/commercialhaskell/stack/releases/download/v3.11.1/stack-3.11.1-osx-aarch64.tar.gz
+              dlHash: 652572ddf74616a7975892de9c61a9e5e6b5979db4f9b00fcd659ac6a15d7330
+              dlSubdir:
+                RegexDir: "stack-.*"
+          Linux_Alpine:
+            unknown_versioning: *stack-3111-arm64


### PR DESCRIPTION
- [x] I have read https://github.com/haskell/ghcup-metadata?tab=readme-ov-file#contributions and https://www.haskell.org/ghcup/dev/
- [x] I did not use an LLM to generate this patch or parts of it
- [x] I understand that PRs may take 1-2 weeks to be reviewed and merged

From Stack's perspective, there is no reason not to recommend this version.